### PR TITLE
[2.3.3] Allow discovery from accounts with minimum permissions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2.3.3]
+
+## Fixed
+- Resource discovery in `config create`command is now done with resource graph query.
+- Extended minimum role assignment to allow `config create`.
+
+## Security
+- Upgraded `System.Text.Json` reference to address vulnerability in version 8.0.4.
+
 ## [2.3.2]
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ## [2.3.3]
 
+## Added
+- `devicecode` variant to `--credential` option.
+
 ## Fixed
 - Resource discovery in `config create`command is now done with resource graph query.
 - Extended minimum role assignment to allow `config create`.

--- a/Version.proj
+++ b/Version.proj
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.3.2</VersionPrefix>
+    <VersionPrefix>2.3.3</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/exekias/Context.cs
+++ b/src/exekias/Context.cs
@@ -38,6 +38,7 @@ public class Context(InvocationContext cmdContext)
             "cli" => new AzureCliCredential(),
             "pwsh" => new AzurePowerShellCredential(),
             "msi" => new ManagedIdentityCredential(),
+            "devicecode" => new DeviceCodeCredential(),
             _ => new ManagedIdentityCredential(option)
         };
     }
@@ -101,7 +102,7 @@ public class Context(InvocationContext cmdContext)
 
     public static Option<string> credentialOption = new(
         "--credential",
-        "Credential to use, one of 'interactive', 'cli', 'pwsh', 'msi' or a GUID of a user assigned managed identity.");
+        "Credential to use, one of 'interactive', 'devicecode', 'cli', 'pwsh', 'msi' or a GUID of a user assigned managed identity.");
 
     public TokenCredential Credential => GetCredential();
 


### PR DESCRIPTION
Permissions set by `exekias backend allow` command were enough for data operation but not enough for discovery in `exekias config create` command. This PR slightly increases the permissions and switches to discovery by Azure resource graph query.