### PR TITLE
Tagging the deployed Azure resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] 2025-01-16
+
 ### Added
 - Tag all deployed resources with `exekias=runstore/blobContainerName`
 - Save exekias configuration to the storage account hidden tag for easy retrieval.
@@ -15,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `exekias config create` command needs just account name as a minimum and is capable to retrieve configuration from the storage account tag.
 
-## [2.4.0]
+## [2.4.0] 2025-01-14
 
 ### Changed
 - `exekias backend deploy` creates storage account with Hierarchical Namespace Support (HNS) enabled to make it compatible wi Data Lakes and Data Lakehouses.
@@ -25,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `exekias data ls` and `exekias data download` skip zero-length blobs which are folders on an HNS-enables blob storage.
 - `exekias backend allow` can now accept a GUID of an EntraID Application object id.
 
-## [2.3.3]
+## [2.3.3] 2024-11-14
 
 ### Added
 - `devicecode` variant to `--credential` option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,31 +6,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+- Tag all deployed resources with `exekias=runstore/blobContainerName`
+- Save exekias configuration to the storage account hidden tag for easy retrieval.
+- Alias `-n` to the `--accountname` option of `exekias` command.
+
+### Changed
+- `exekias config create` command needs just account name as a minimum and is capable to retrieve configuration from the storage account tag.
+
 ## [2.4.0]
 
-## Changed
+### Changed
 - `exekias backend deploy` creates storage account with Hierarchical Namespace Support (HNS) enabled to make it compatible wi Data Lakes and Data Lakehouses.
 - changed default names of a few deployed resources, most notable Cosmos DB account which now has the name of corresponding storage account.
 
-## Fixed
+### Fixed
 - `exekias data ls` and `exekias data download` skip zero-length blobs which are folders on an HNS-enables blob storage.
 - `exekias backend allow` can now accept a GUID of an EntraID Application object id.
 
 ## [2.3.3]
 
-## Added
+### Added
 - `devicecode` variant to `--credential` option.
 
-## Fixed
+### Fixed
 - Resource discovery in `config create`command is now done with resource graph query.
 - Extended minimum role assignment to allow `config create`.
 
-## Security
+### Security
 - Upgraded `System.Text.Json` reference to address vulnerability in version 8.0.4.
 
 ## [2.3.2]
 
-## Fixed
+### Fixed
 - In `exekias backend deploy` command, restart of function app after ARM deployment is now synchronous
   in an attempt to avoid utility hang at the function code deployment stage.
 - Backend uses EntraID identity and RBAC to access Batch account.

--- a/Version.proj
+++ b/Version.proj
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.4.0</VersionPrefix>
+    <VersionPrefix>2.5.0</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/exekias/Backend.cs
+++ b/src/exekias/Backend.cs
@@ -171,6 +171,20 @@ partial class Worker
         WriteLine("Adding application package to batch account.");
         PoolAssignApplication(batchPoolId!,
             UploadBatchApplicationPackage(tablesPath, batchAccountId!, "dataimport", "1.0.0"));
+
+        // store the configuration in the run store hidden tag
+        var cfg = new ExekiasConfig(
+            runStoreUrl: runStore.Data.PrimaryEndpoints.BlobUri.ToString(),
+            runStoreMetadataFilePattern: metadataFilePattern,
+            exekiasStoreEndpoint: metaStore.Data.DocumentEndpoint,
+            exekiasStoreDatabaseName: "Exekias",
+            exekiasStoreContainerName: containerName
+        );
+        // Add a tag to the runstore resource
+        var tags = runStore.Data.Tags;
+        var patch = new StorageAccountPatch();
+        patch.Tags[$"hidden-exekias-config-{containerName}"] = System.Text.Json.JsonSerializer.Serialize(cfg);
+        runStore.Update(patch);
     }
 
     WebSiteResource DeployFunctionCode(WebSiteResource funcApp, string zipPath, string expected)

--- a/src/exekias/Backend.cs
+++ b/src/exekias/Backend.cs
@@ -173,17 +173,9 @@ partial class Worker
             UploadBatchApplicationPackage(tablesPath, batchAccountId!, "dataimport", "1.0.0"));
 
         // store the configuration in the run store hidden tag
-        var cfg = new ExekiasConfig(
-            runStoreUrl: runStore.Data.PrimaryEndpoints.BlobUri.ToString(),
-            runStoreMetadataFilePattern: metadataFilePattern,
-            exekiasStoreEndpoint: metaStore.Data.DocumentEndpoint,
-            exekiasStoreDatabaseName: "Exekias",
-            exekiasStoreContainerName: containerName
-        );
-        // Add a tag to the runstore resource
-        var tags = runStore.Data.Tags;
         var patch = new StorageAccountPatch();
-        patch.Tags[$"hidden-exekias-config-{containerName}"] = System.Text.Json.JsonSerializer.Serialize(cfg);
+        patch.Tags[$"hidden-exekias-pattern-{containerName}"] = metadataFilePattern;
+        patch.Tags[$"hidden-exekias-cosmos-{containerName}"] = $"{metaStore.Get().Value.Data.DocumentEndpoint}Exekias/{containerName}";
         runStore.Update(patch);
     }
 

--- a/src/exekias/Config.cs
+++ b/src/exekias/Config.cs
@@ -175,8 +175,26 @@ partial class Worker
         return account;
     }
 
+    /// <summary>
+    /// Ask for an existing storage account.
+    /// </summary>
+    /// <param name="storageAccountName">Storage account name if known.</param>
+    /// <param name="resourceGroup">Case insensitive Azure resource group name if known.</param>
+    /// <param name="subscription">Case insensitive Azure subscription name or id if known</param>
+    /// <returns><see cref="StorageAccountResource"/> object; data not loaded yet.</returns>
+    /// <exception cref="ArgumentException">A name is specified, but the resource doesn't exist.</exception>
+    /// <exception cref="InvalidOperationException">A name is not specified and cannot be requested interactively.</exception>
     StorageAccountResource AskExistingStorageAccount(string? storageAccountName, string? resourceGroup, string? subscription)
     {
+        if (storageAccountName != null)
+        {
+            var found = StorageAccountId(storageAccountName);
+            if (found == null)
+            {
+                throw new ArgumentException($"Storage account {storageAccountName} not found or inaccessible.");
+            }
+            return Arm.GetStorageAccountResource(ResourceIdentifier.Parse(found));
+        }
         var subscriptions = StorageSubscriptions();
         string subscriptionId = "";
         if (subscription != null)
@@ -230,16 +248,7 @@ partial class Worker
         }
 
         var storageAccounts = Array.ConvertAll(StorageAccountIds(subscriptionId, resourceGroup), id => ResourceIdentifier.Parse(id));
-        if (storageAccountName != null)
-        {
-            var foundSA = Array.FindIndex(storageAccounts, item => string.Compare(item.Name, storageAccountName, StringComparison.InvariantCultureIgnoreCase) == 0);
-            if (foundSA < 0)
-            {
-                throw new ArgumentException($"Storage account {storageAccountName} not found or inaccessible.");
-            }
-            return Arm.GetStorageAccountResource(storageAccounts[foundSA]);
-        }
-        else if (storageAccounts.Length == 1)
+        if (storageAccounts.Length == 1)
         {
             WriteLine($"Using storage account {storageAccounts[0].Name}.");
             return Arm.GetStorageAccountResource(storageAccounts[0]);
@@ -309,24 +318,34 @@ partial class Worker
     }
 
     string AskBlobContainerName(string? blobContainerName, StorageAccountResource storageAccount)
+        => AskBlobContainerName(
+            blobContainerName,
+            storageAccount
+                .GetBlobService()
+                .GetBlobContainers()
+                .AsEnumerable()
+                .Select(c => c.Data.Name)
+                .ToList()
+            );
+
+    string AskBlobContainerName(string? blobContainerName, IList<string> all, bool createNew = true)
     {
-        var all = storageAccount.GetBlobService().GetBlobContainers();
         if (blobContainerName != null)
         {
-            if (all.Exists(blobContainerName))
+            if (all.Contains(blobContainerName))
             {
                 return blobContainerName;
             }
             else
             {
-                throw new InvalidOperationException($"{blobContainerName} does not exist in storage account {storageAccount.Data.Name}");
+                throw new InvalidOperationException($"{blobContainerName} does not exist.");
             }
         }
         if (IsInputRedirected)
         {
-            throw new InvalidOperationException("Specify Azure resource group name using --blobcontainer option.");
+            throw new InvalidOperationException("Specify blob container name using --blobcontainer option.");
         }
-        var chosen = Choose("Blob containers:", Array.ConvertAll(all.GetAll().ToArray(), a => a.Data.Name), true);
+        var chosen = Choose("Blob containers:", all, createNew);
         if (chosen < 0)
         {
             // ask for a new blob container name
@@ -346,7 +365,7 @@ partial class Worker
             }
             return name;
         }
-        return all.GetAll().ToArray()[chosen].Data.Name;
+        return all[chosen];
     }
 
     SystemTopicEventSubscriptionResource? FindEventSubscription(ResourceIdentifier storageAccount, string? blobContainerName)
@@ -414,23 +433,55 @@ partial class Worker
         }
         try
         {
-            var storageAccount = AskExistingStorageAccount(storageAccountName, resourceGroupName, subscription);
-            var appSettings = FindWebSiteSettings(storageAccount.Id, blobContainerName);
-            if (appSettings == null)
+            StorageAccountResource storageAccount = AskExistingStorageAccount(storageAccountName, resourceGroupName, subscription).Get();
+            var tagPrefix = "hidden-exekias-config-";
+            // build containerName => exekiasConfig map
+            var taggedConfigs = storageAccount.Data.Tags
+                .Where(kv => kv.Key.StartsWith(tagPrefix))
+                .ToDictionary(kv => kv.Key.Substring(tagPrefix.Length), kv => kv.Value);
+            if (taggedConfigs.Count > 0)
             {
-                return 1;
+                if (blobContainerName != null && !taggedConfigs.ContainsKey(blobContainerName))
+                {
+                    WriteError($"No Exekias for container {blobContainerName}. Existing configurations: {string.Join(", ", taggedConfigs.Keys)}");
+                    return 1;
+                }
+                if (blobContainerName == null)
+                {
+                    if (taggedConfigs.Count == 1)
+                    {
+                        blobContainerName = taggedConfigs.Keys.First();
+                    }
+                    else
+                    {
+                        blobContainerName = AskBlobContainerName(null, taggedConfigs.Keys.ToList(), false);
+                    }
+                }
+                File.WriteAllText(ConfigFile.FullName, taggedConfigs[blobContainerName]);
+                WriteLine($"Configuration copied in {ConfigFile.FullName}.");
+                return 0;
             }
-            var cfg = new ExekiasConfig(
-                runStoreUrl: appSettings.Properties["RunStore__BlobContainerUrl"],
-                runStoreMetadataFilePattern: appSettings.Properties["RunStore__MetadataFilePattern"],
-                exekiasStoreEndpoint: appSettings.Properties["ExekiasCosmos__Endpoint"],
-                exekiasStoreDatabaseName: appSettings.Properties.TryGetValue("ExekiasCosmos__DatabaseName", out string? dnValue) && dnValue != null ? dnValue : "Exekias",
-                exekiasStoreContainerName: appSettings.Properties.TryGetValue("ExekiasCosmos__ContainerName", out string? cnValue) && cnValue != null ? cnValue : "Runs"
-                );
-            using var file = ConfigFile.OpenWrite();
-            JsonSerializer.Serialize(file, cfg);
-            WriteLine($"Configuration saved in {ConfigFile.FullName}.");
-            return 0;
+            else
+            {
+                // For compatibility with previous versions, 
+                // find a function app and read configuration from its settings
+                var appSettings = FindWebSiteSettings(storageAccount.Id, blobContainerName);
+                if (appSettings == null)
+                {
+                    return 1;
+                }
+                var cfg = new ExekiasConfig(
+                    runStoreUrl: appSettings.Properties["RunStore__BlobContainerUrl"],
+                    runStoreMetadataFilePattern: appSettings.Properties["RunStore__MetadataFilePattern"],
+                    exekiasStoreEndpoint: appSettings.Properties["ExekiasCosmos__Endpoint"],
+                    exekiasStoreDatabaseName: appSettings.Properties.TryGetValue("ExekiasCosmos__DatabaseName", out string? dnValue) && dnValue != null ? dnValue : "Exekias",
+                    exekiasStoreContainerName: appSettings.Properties.TryGetValue("ExekiasCosmos__ContainerName", out string? cnValue) && cnValue != null ? cnValue : "Runs"
+                    );
+                using var file = ConfigFile.OpenWrite();
+                JsonSerializer.Serialize(file, cfg);
+                WriteLine($"Configuration saved in {ConfigFile.FullName}.");
+                return 0;
+            }
         }
         catch (InvalidOperationException ex)
         {

--- a/src/exekias/Program.cs
+++ b/src/exekias/Program.cs
@@ -17,7 +17,7 @@ var azureSubscriptionOption = new Option<string?>(["--subscription", "-s"], "Azu
 configCreateCommand.AddOption(azureSubscriptionOption);
 var resourceGroupOption = new Option<string?>(["--resourcegroup", "-g"], "Azure resource group name.");
 configCreateCommand.AddOption(resourceGroupOption);
-var storageAccountOption = new Option<string?>("--storageaccount", "Azure storage account name.");
+var storageAccountOption = new Option<string?>(["--storageaccount", "-n"], "Azure storage account name.");
 configCreateCommand.AddOption(storageAccountOption);
 var blobContainerOption = new Option<string>("--blobcontainer", "Blob container name. For a new sttorage account the default container name is 'runs'.");
 configCreateCommand.AddOption(blobContainerOption);

--- a/src/exekias/main.bicep
+++ b/src/exekias/main.bicep
@@ -33,7 +33,7 @@ resource topic 'Microsoft.EventGrid/systemTopics@2022-06-15' = {
     topicType: 'Microsoft.Storage.StorageAccounts'
   }
   tags:{
-    exekias: runStoreName
+    exekias: '${runStoreName}/${storeContainer}'
   }
 }
 
@@ -57,7 +57,7 @@ resource syncMeta 'Microsoft.DocumentDB/databaseAccounts@2023-11-15' = {
     ]
   }
   tags:{
-    exekias: runStoreName
+    exekias: '${runStoreName}/${storeContainer}'
   }
 
   resource db 'sqlDatabases' = {
@@ -177,7 +177,7 @@ resource syncStore 'Microsoft.Storage/storageAccounts@2023-04-01' = {
     allowSharedKeyAccess: false
   }
   tags:{
-    exekias: runStoreName
+    exekias: '${runStoreName}/${storeContainer}'
   }
 }
 
@@ -208,7 +208,7 @@ resource batchAccount 'Microsoft.Batch/batchAccounts@2024-02-01' = {
     }
   }
   tags:{
-    exekias: runStoreName
+    exekias: '${runStoreName}/${storeContainer}'
   }
 }
 
@@ -216,7 +216,7 @@ resource poolIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-
   location: location
   name: '${runStoreName}-batch-pool-identity'
   tags:{
-    exekias: runStoreName
+    exekias: '${runStoreName}/${storeContainer}'
   }
 }
 
@@ -350,7 +350,7 @@ resource syncApp 'Microsoft.Web/sites@2023-12-01' = {
     }
   }
   tags:{
-    exekias: runStoreName
+    exekias: '${runStoreName}/${storeContainer}'
   }
 }
 
@@ -484,7 +484,7 @@ resource logStore 'Microsoft.Insights/components@2020-02-02' = {
     WorkspaceResourceId: workspace.id
   }
   tags:{
-    exekias: runStoreName
+    exekias: '${runStoreName}/${storeContainer}'
   }
 }
 
@@ -492,7 +492,7 @@ resource workspace 'Microsoft.OperationalInsights/workspaces@2020-10-01' = {
   name: syncName
   location: location
   tags:{
-    exekias: runStoreName
+    exekias: '${runStoreName}/${storeContainer}'
   }
 }
 
@@ -509,6 +509,6 @@ resource hostingPlan 'Microsoft.Web/serverfarms@2022-03-01' = {
     reserved: true // Linux
   }
   tags:{
-    exekias: runStoreName
+    exekias: '${runStoreName}/${storeContainer}'
   }
 }

--- a/src/exekias/main.bicep
+++ b/src/exekias/main.bicep
@@ -14,7 +14,7 @@ var syncFunctionName = '${syncName}-${storeContainer}'
 // RunStore storage
 resource runStore 'Microsoft.Storage/storageAccounts@2023-04-01' existing = {
   name: runStoreName
-
+  
   resource blobService 'blobServices' = {
     name: 'default'
     
@@ -31,6 +31,9 @@ resource topic 'Microsoft.EventGrid/systemTopics@2022-06-15' = {
   properties: {
     source: runStore.id
     topicType: 'Microsoft.Storage.StorageAccounts'
+  }
+  tags:{
+    exekias: runStoreName
   }
 }
 
@@ -52,6 +55,9 @@ resource syncMeta 'Microsoft.DocumentDB/databaseAccounts@2023-11-15' = {
         name: 'EnableServerless'
       }
     ]
+  }
+  tags:{
+    exekias: runStoreName
   }
 
   resource db 'sqlDatabases' = {
@@ -170,6 +176,9 @@ resource syncStore 'Microsoft.Storage/storageAccounts@2023-04-01' = {
     allowBlobPublicAccess: false
     allowSharedKeyAccess: false
   }
+  tags:{
+    exekias: runStoreName
+  }
 }
 
 resource syncBlobService 'Microsoft.Storage/storageAccounts/blobServices@2023-04-01' = {
@@ -198,11 +207,17 @@ resource batchAccount 'Microsoft.Batch/batchAccounts@2024-02-01' = {
       }
     }
   }
+  tags:{
+    exekias: runStoreName
+  }
 }
 
 resource poolIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
   location: location
   name: '${runStoreName}-batch-pool-identity'
+  tags:{
+    exekias: runStoreName
+  }
 }
 
 resource batchPool 'Microsoft.Batch/batchAccounts/pools@2024-02-01' = {
@@ -334,6 +349,9 @@ resource syncApp 'Microsoft.Web/sites@2023-12-01' = {
       ]
     }
   }
+  tags:{
+    exekias: runStoreName
+  }
 }
 
 resource ContributorRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
@@ -379,7 +397,7 @@ resource functionSyncBlobOwnerRoleAssignment 'Microsoft.Authorization/roleAssign
   }
 }
 
-resource functionSyncQueueContrinutorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+resource functionSyncQueueContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   scope: syncStore
   name: guid(syncApp.id, syncStore.id, queueDataContributorRoleDefinition.id)
   properties: {
@@ -389,7 +407,7 @@ resource functionSyncQueueContrinutorRoleAssignment 'Microsoft.Authorization/rol
   }
 }
 
-resource functionSyncTableContrinutorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+resource functionSyncTableContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   scope: syncStore
   name: guid(syncApp.id, syncStore.id, tableDataContributorRoleDefinition.id)
   properties: {
@@ -465,11 +483,17 @@ resource logStore 'Microsoft.Insights/components@2020-02-02' = {
     Application_Type: 'general'
     WorkspaceResourceId: workspace.id
   }
+  tags:{
+    exekias: runStoreName
+  }
 }
 
 resource workspace 'Microsoft.OperationalInsights/workspaces@2020-10-01' = {
   name: syncName
   location: location
+  tags:{
+    exekias: runStoreName
+  }
 }
 
 resource hostingPlan 'Microsoft.Web/serverfarms@2022-03-01' = {
@@ -483,5 +507,8 @@ resource hostingPlan 'Microsoft.Web/serverfarms@2022-03-01' = {
   }
   properties: {
     reserved: true // Linux
+  }
+  tags:{
+    exekias: runStoreName
   }
 }


### PR DESCRIPTION
### Added
- Tag all deployed resources with `exekias=runstore/blobContainerName`
- Save exekias configuration to the storage account hidden tag for easy retrieval.
- Alias `-n` to the `--accountname` option of `exekias` command.

### Changed
- `exekias config create` command needs just account name as a minimum and is capable to retrieve configuration from the storage account tag.