### PR TITLE
[2.5.2] fix exekias config create for older storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [2.5.2] 2025-01-29
+
+### Fixed
+- regression bug in `exekias config create` command: for older storage didn't request mandatory container name.
+
 ## [2.5.1] 2025-01-17
 
 ### Fixed

--- a/Version.proj
+++ b/Version.proj
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.1</VersionPrefix>
+    <VersionPrefix>2.5.2</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/exekias/Config.cs
+++ b/src/exekias/Config.cs
@@ -480,6 +480,10 @@ partial class Worker
             {
                 // For compatibility with previous versions, 
                 // find a function app and read configuration from its settings
+                if (blobContainerName == null)
+                {
+                    blobContainerName = AskBlobContainerName(null, storageAccount);
+                }
                 var appSettings = FindWebSiteSettings(storageAccount.Id, storageAccount.Data.PrimaryEndpoints.BlobUri + blobContainerName);
                 if (appSettings == null)
                 {


### PR DESCRIPTION
### Fixed
- regression bug in `exekias config create` command: for older storage didn't request mandatory container name.
