### PR TITLE
[2.5.3] widen permissions to allow users run custom batch jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
-## [2.5.2] 2025-01-29
+## [2.5.3] 2025-02-12
 
 ### Changed
 - widen permissions to allow a user to spawn batch jobs that write back to the storage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.5.2] 2025-01-29
 
+### Changed
+- widen permissions to allow a user to spawn batch jobs that write back to the storage.
+
+## [2.5.2] 2025-01-29
+
 ### Fixed
 - regression bug in `exekias config create` command: for older storage didn't request mandatory container name.
 

--- a/Version.proj
+++ b/Version.proj
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.2</VersionPrefix>
+    <VersionPrefix>2.5.3</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/exekias/Backend.cs
+++ b/src/exekias/Backend.cs
@@ -277,6 +277,10 @@ partial class Worker
 
         // to allow custom batch jobs
         Authorize("batch account", batch, "Contributor", principalId);
+        ResourceIdentifier msiId = batch.Get().Value.Data.AutoStorage.NodeIdentityResourceId;
+        var msiResource = Arm.GetGenericResource(msiId);  // Managed identity
+        // to allow users to assign the managed identity to a new pool
+        Authorize("pool identity", msiResource, "Managed Identity Operator", principalId);
     }
 
     async Task<(Guid principalId, string principalName)> GetPrincipal(string principalId)

--- a/src/exekias/main.bicep
+++ b/src/exekias/main.bicep
@@ -447,13 +447,13 @@ resource batchSyncDataContributorRoleAssignment 'Microsoft.Authorization/roleAss
   }
 }
 
-resource poolRunDataReaderRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+resource poolRunDataContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   scope: runStore
-  name: guid(poolIdentity.id, runStore.id, blobDataReaderRoleDefinition.id)
+  name: guid(poolIdentity.id, runStore.id, blobDataContributorRoleDefinition.id)
   properties: {
     principalId: poolIdentity.properties.principalId
     principalType: 'ServicePrincipal' // see https://learn.microsoft.com/en-gb/azure/role-based-access-control/role-assignments-template#new-service-principal
-    roleDefinitionId: blobDataReaderRoleDefinition.id
+    roleDefinitionId: blobDataContributorRoleDefinition.id
   }
 }
 


### PR DESCRIPTION
### Changed
- widen permissions to allow a user to spawn batch jobs that write back to the storage.
