### PR TITLE
[2.5.5] Fix progress indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ## [2.5.5] 2025-05-23
 
+### Changed
+- data upload and download command now accept `--verbosity` option to lower the verbosity when trasferring a lot of files.
+  Old verbose behaviour can be reproduced with `--verbosity verbose`.
+
 ### Fixed
 - Collection was modified error in `ProgressIndicator`
 - Error getting pwsh credential from Az.Accounts >= 5.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.5.5] 2025-05-23
 
 ### Fixed
-- prevent "Collection was modified" error in `ProgressIndicator`
+- Collection was modified error in `ProgressIndicator`
+- Error getting pwsh credential from Az.Accounts >= 5.0.1
 
 ## [2.5.4] 2025-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2.5.5] 2025-05-23
+
+### Fixed
+- prevent "Collection was modified" error in `ProgressIndicator`
+
 ## [2.5.4] 2025-03-23
 
 ### Fixed

--- a/Version.proj
+++ b/Version.proj
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.5.3</VersionPrefix>
+    <VersionPrefix>2.5.5</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/Exekias.AzureStores/Exekias.AzureStores.csproj
+++ b/src/Exekias.AzureStores/Exekias.AzureStores.csproj
@@ -8,10 +8,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.16.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 	</ItemGroup>
 

--- a/src/Exekias.Core.Azure/Exekias.Core.Azure.csproj
+++ b/src/Exekias.Core.Azure/Exekias.Core.Azure.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Azure.Identity" Version="1.14.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
   </ItemGroup>
 

--- a/src/Exekias.Core.Azure/Exekias.Core.Azure.csproj
+++ b/src/Exekias.Core.Azure/Exekias.Core.Azure.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.14.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Exekias.Core/Exekias.Core.csproj
+++ b/src/Exekias.Core/Exekias.Core.csproj
@@ -8,10 +8,10 @@
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/Exekias.CosmosDb/Exekias.CosmosDb.csproj
+++ b/src/Exekias.CosmosDb/Exekias.CosmosDb.csproj
@@ -15,10 +15,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.41.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 

--- a/src/Exekias.CosmosDb/Exekias.CosmosDb.csproj
+++ b/src/Exekias.CosmosDb/Exekias.CosmosDb.csproj
@@ -16,9 +16,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.41.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 

--- a/src/Exekias.DataImport/Exekias.DataImport.csproj
+++ b/src/Exekias.DataImport/Exekias.DataImport.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<UserSecretsId>exekias-dev</UserSecretsId>

--- a/src/Exekias.SDS.Blob.Batch/ImportStoreBlobBatch.cs
+++ b/src/Exekias.SDS.Blob.Batch/ImportStoreBlobBatch.cs
@@ -56,8 +56,8 @@ namespace Exekias.SDS.Blob.Batch
                  from kv in configuration.GetSection(name).AsEnumerable()
                  where kv.Value != null
                  select kv)
-                .Append(new KeyValuePair<string, string>(AppInsightsKey, configuration[AppInsightsKey]))
-                .Append(new KeyValuePair<string, string>(ManagedIdentityKey, configuration[PoolIdentityKey]))
+                .Append(new KeyValuePair<string, string>(AppInsightsKey, configuration[AppInsightsKey] ?? ""))
+                .Append(new KeyValuePair<string, string>(ManagedIdentityKey, configuration[PoolIdentityKey]?? ""))
                 .ToImmutableArray();
         }
 

--- a/src/Exekias.SDS/Exekias.SDS.csproj
+++ b/src/Exekias.SDS/Exekias.SDS.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageReference Include="SDSLite" Version="3.0.1" />
     <PackageReference Include="System.Security.Permissions" Version="4.7.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/src/exekias/Backend.cs
+++ b/src/exekias/Backend.cs
@@ -136,7 +136,7 @@ partial class Worker
                 WriteLine($"  {subResource.Id}");
             }
         }
-        var deploymentOutput = deployment.Data.Properties.Outputs.ToObjectFromJson<JsonObject>();
+        var deploymentOutput = deployment.Data.Properties.Outputs.ToObjectFromJson<JsonObject>() ?? throw new InvalidOperationException("Cannot parse deployment outputs.");
         var syncFunctionId = deploymentOutput["syncFunctionId"]?["value"]?.GetValue<string?>();
         var batchAccountId = deploymentOutput["batchAccountId"]?["value"]?.GetValue<string?>();
         var batchPoolId = deploymentOutput["batchPoolId"]?["value"]?.GetValue<string?>();

--- a/src/exekias/Context.cs
+++ b/src/exekias/Context.cs
@@ -17,6 +17,14 @@ public record ExekiasConfig(
     [property: JsonRequired] string exekiasStoreDatabaseName,
     [property: JsonRequired] string exekiasStoreContainerName);
 
+
+public enum Verbosity
+{
+    Minimal,
+    Normal,
+    Verbose
+}
+
 public class Context(InvocationContext cmdContext)
 {
     #region implemetation
@@ -115,6 +123,10 @@ public class Context(InvocationContext cmdContext)
         "--credential",
         "Credential to use, one of 'interactive', 'devicecode', 'cli', 'pwsh', 'msi' or a GUID of a user assigned managed identity.");
 
+    public static Option<Verbosity> verbosityOption = new ("--verbosity", () => Verbosity.Normal, "Set progress verbosity level.");
+
+    public Verbosity VerbosityLevel => cmdContext.ParseResult.GetValueForOption(verbosityOption);
+    
     public TokenCredential Credential => GetCredential();
 
     public ArmClient Arm => GetArmClient();
@@ -182,7 +194,7 @@ public class Context(InvocationContext cmdContext)
 
     public ProgressIndicator CreateProgressIndicator()
     {
-        return new ProgressIndicator(cmdContext.Console);
+        return new ProgressIndicator(cmdContext.Console, VerbosityLevel);
     }
 
     public ExekiasConfig Config => GetConfig() ?? throw new ArgumentNullException("No configuration file found.");

--- a/src/exekias/Program.cs
+++ b/src/exekias/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System.CommandLine;
 
+
 var rootCommand = new RootCommand("Exekias configuration");
 rootCommand.AddGlobalOption(Context.configOption);
 rootCommand.AddGlobalOption(Context.credentialOption);
@@ -82,6 +83,7 @@ dataLsCommand.SetHandler(async ctx => ctx.ExitCode = await new Worker(ctx).DoDat
 
 // data upload <path> -- upload a run in a local folder.
 var dataUploadCommand = new Command("upload", "Upload a run in a local folder.");
+dataUploadCommand.AddOption(Context.verbosityOption);
 var dataUploadPathArgument = new Argument<string>("path", "Path to a directory with files of the run. " +
     "The directory must have a metadata file and its name must match regular expression. " +
     "See MetadataFilePath configuration value as displayed by 'config' command.");
@@ -92,6 +94,7 @@ dataCommand.AddCommand(dataUploadCommand);
 
 // data download <run> <path>
 var dataDownloadCommand = new Command("download", "Download a run as a subfolder at the specified path.");
+dataDownloadCommand.AddOption(Context.verbosityOption);
 dataDownloadCommand.AddArgument(runIdArgument);
 var dataDownloadPathArgument = new Argument<string>("path", "A directory path to create the subfolder.");
 dataDownloadCommand.AddArgument(dataDownloadPathArgument);
@@ -154,4 +157,3 @@ backendBatchAppUploadCommand.SetHandler(ctx => new Worker(ctx).DoBackendBatchApp
     ctx.ParseResult.GetValueForArgument(backendBatchAppUploadVersionArgument)));
 
 return await rootCommand.InvokeAsync(args);
-

--- a/src/exekias/exekias.csproj
+++ b/src/exekias/exekias.csproj
@@ -36,7 +36,7 @@
 	
 	<ItemGroup>
 		<AdditionalProject Include="..\Exekias.DataImport\Exekias.DataImport.csproj">
-			<MSBuildProperties>RuntimeIdentifier=win-x64;SelfContained=false</MSBuildProperties>
+			<MSBuildProperties>RuntimeIdentifier=win-x64;SelfContained=true</MSBuildProperties>
 		</AdditionalProject>
 		<AdditionalProject Include="..\Exekias.AzureFunctions\Exekias.AzureFunctions.csproj">
 			<MSBuildProperties>RuntimeIdentifier=linux-x64;SelfContained=false</MSBuildProperties>

--- a/src/exekias/exekias.csproj
+++ b/src/exekias/exekias.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="Azure.Bicep.MSBuild" Version="0.27.1" />
 		<PackageReference Include="Azure.Bicep.CommandLine.win-x64" Version="0.27.1" />
-		<PackageReference Include="Azure.Identity" Version="1.12.0" />
+		<PackageReference Include="Azure.Identity" Version="1.14.0" />
 		<PackageReference Include="Azure.ResourceManager.AppService" Version="1.0.1" />
 		<PackageReference Include="Azure.ResourceManager.Authorization" Version="1.1.3" />
 		<PackageReference Include="Azure.ResourceManager.Batch" Version="1.4.0" />


### PR DESCRIPTION
### Changed
- data upload and download command now accept `--verbosity` option to lower the verbosity when trasferring a lot of files.
  Old verbose behaviour can be reproduced with `--verbosity verbose`.

### Fixed
- Collection was modified error in `ProgressIndicator`
- Error getting pwsh credential from Az.Accounts >= 5.0.1
