### PR TITLE
Fix incorrect Relative Path on Windows

### DIFF
--- a/integration-test.ps1
+++ b/integration-test.ps1
@@ -25,9 +25,7 @@ if (Test-Path $sample_folder) {
 $upload_folder = New-Item -Path "$upload_relative_path/sub folder" -ItemType Directory | Select-Object -ExpandProperty Parent
 
 Set-Content -Path "$upload_folder/params.json" -Value '{"testKey": "test value"}'
-# On Linux backslashes are allowed in file names
-if ($IsLinux) { $data_file_name = "data\file.csv" } else { $data_file_name = "data.csv" }
-Set-Content -Path "$upload_folder/$data_file_name" -Value @'
+Set-Content -Path "$upload_folder/data.csv" -Value @'
 columnTitle
 columnValue
 '@

--- a/integration-test.ps1
+++ b/integration-test.ps1
@@ -84,12 +84,13 @@ try {
             subst x: "$sample_folder/upload"
             Write-Host "[$(Get-Date)] Testing upload from a substituted drive x:\$runid ..."
             # same data, reports 3 files total, 0 files uploaded
-            $output = & $exekias data upload "x:\$runid"            
-            if (-not $output.Contains("3 skipped")) {
+            $output = & $exekias data upload "x:\$runid" 
+            $output = $output[-1]  # last line contains the summary    
+            if (-not $output.Contains(", skipped 3")) {
                 Write-Error "Upload from a substituted drive failed: $output"
                 exit 1
             }
-            Write-Host "[$(Get-Date)] The run matched, all files skipped as expected."
+            Write-Host "[$(Get-Date)] $output"
         }
         finally {
             subst /d x:

--- a/src/exekias/Data.cs
+++ b/src/exekias/Data.cs
@@ -58,7 +58,7 @@ partial class Worker
             dir.GetFiles("*", SearchOption.AllDirectories),
             fi => (
                 info: fi,
-                blobName: fi.FullName.Substring(prefixLength).Replace(@"\", "/")
+                blobName: Path.GetRelativePath(dir.Parent.FullName, fi.FullName).Replace("\\", "/")
         ));
         // check that the directory contains a file matching regular expression runStoreMetadataFilePattern
         var metadataFilePattern = new System.Text.RegularExpressions.Regex(Config.runStoreMetadataFilePattern);


### PR DESCRIPTION
This closes #28 

This passes locally.
```bash
dotnet test --verbosity normal src/Exekias.Core.Tests
```

Built and tested locally - with two changes #including #31   it works fine!
<img width="1376" height="150" alt="image" src="https://github.com/user-attachments/assets/fa1dd5d0-f21f-4985-b2cc-e77d801e1f91" />